### PR TITLE
Clean up the main loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,15 +20,6 @@ const callWithTimeout = async (promise, timeLimit) => {
     return Promise.race([promise, timeoutPromise]);
 }
 
-let previous = "";
-let input = "";
-let next = "";
-let context = "";
-let subtitle;
-
-let subtitles = fs.readdirSync('./src');
-let supportExtensions = ['srt', 'vtt'];
-
 /**
 * Completes a chat gpt request. Even if the request times out, it'll retry automatically
 * and eventually return the result.
@@ -90,11 +81,13 @@ function translateInPlace(subtitles) {
   return subtitles;
 }
 
-for (let subtitleFile of subtitles) {
+const subtitleFiles = fs.readdirSync('./src');
+const supportExtensions = ['srt', 'vtt'];
+for (let subtitleFile of subtitleFiles) {
   if (!supportExtensions.includes(subtitleFile.split('.').pop())) continue
-  subtitle = fs.readFileSync(`./src/${subtitleFile}`, 'utf8')
-  subtitle = parseSync(subtitle)
-  subtitle = subtitle.filter(line => line.type === 'cue')
+  const subtitles = fs.readFileSync(`./src/${subtitleFile}`, 'utf8')
+  subtitles = parseSync(subtitle)
+  subtitles = subtitles.filter(line => line.type === 'cue')
 
   translateInPlace(subtitles);
   

--- a/index.js
+++ b/index.js
@@ -9,19 +9,15 @@ const configuration = new Configuration({
 });
 const openai = new OpenAIApi(configuration);
 
-
-const asyncCallWithTimeout = async (asyncPromise, timeLimit) => {
-    let timeoutHandle;
-    const timeoutPromise = new Promise((_resolve, reject) => {
-        timeoutHandle = setTimeout(
-            () => _resolve("TIMEOUT"),
-            timeLimit
-        );
+/**
+* Resolves a promise with a given timeout. If the timeout is reached before the promise
+* resolves, the Promise gets rejected.
+*/
+const callWithTimeout = async (promise, timeLimit) => {
+    const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(reject, timeLimit);
     });
-    return Promise.race([asyncPromise, timeoutPromise]).then(result => {
-        clearTimeout(timeoutHandle);
-        return result;
-    })
+    return Promise.race([promise, timeoutPromise]);
 }
 
 let previous = "";
@@ -33,54 +29,65 @@ let subtitle;
 let subtitles = fs.readdirSync('./src');
 let supportExtensions = ['srt', 'vtt'];
 
-var translateSubtitleLine = async function(i, filename) {
-  if (input) {
-    previous = input;
-  }
-  input = subtitle[i].data.text;
-
-  if (subtitle[i + 1] && subtitle[i + 1].data.text.length > 0) {
-    next = subtitle[i + 1].data.text;
-  }
-  context = previous + input + next;
-  let msgToGpt = {
-    model: "gpt-3.5-turbo",
-    messages: [
-      {
-        role: "system",
-        content: `You are a program translating input text. People or place names should be translated. Expected output: Only the translation. In case of doubt, make a guess. Target language: ${config.TARGET_LANGUAGE}`
-      },
-      {
-        role: "user",
-        content: `In the sentence "我喜歡騎腳踏車但我更喜歡跑步" please translate the part "腳踏車" and just output the translated text`
-      },
-      {
-        role: "assistant",
-        content: `bicycle`
-      },
-      {
-        role: "user",
-        content: `In the sentence "${context}" please translate the part "${input}" and just output the translated text`
-      }
-    ]
-  }
-
-    const completion = await asyncCallWithTimeout(openai.createChatCompletion(msgToGpt), 5000);
-    if (completion === "TIMEOUT") {
-      translateSubtitleLine(i, filename);
-    } else {
-      let result = completion.data.choices[0].message.content;
-      subtitle[i].data.text = `${result}\n${input}`
-      console.log(`-----------------`)
-      console.log(`${i + 1} / ${subtitle.length}`)
-      console.log(`${result}`)
-      console.log(`${input}`);
-      if (i === subtitle.length-1) {
-        fs.writeFileSync(`./res/${filename}`, stringifySync(subtitle, { format: 'srt' }))
-      } else {
-        translateSubtitleLine(i+1, filename);
-      }
+/**
+* Completes a chat gpt request. Even if the request times out, it'll retry automatically
+* and eventually return the result.
+*/
+function createChatCompletionWithRetries(msgToGpt) {
+  let result;
+  while (!result) {
+    try {
+      result = await asyncCallWithTimeout(openai.createChatCompletion(msgToGpt), 5000);
+    } catch (_) {
+      // Retry.
     }
+  }
+  return result;
+}
+
+/**
+* Translates an array of subtitles in-place. The data is added to subtitles[i].data.text.
+*/
+function translateInPlace(subtitles) {
+  // TODO: fix the starting data.
+  let previous, current = subtitles[0].data.text, next = subtitles[1].data.text;
+  for (let i = 0; i < subtitles.length; i++) {
+    previous = current;
+    current = next;
+    next = subtitles[i + 1].data.text;
+
+    const context = previous + input + next;
+    const msgToGpt = {
+      model: "gpt-3.5-turbo",
+      messages: [
+        {
+          role: "system",
+          content: `You are a program translating input text. People or place names should be translated. Expected output: Only the translation. In case of doubt, make a guess. Target language: ${config.TARGET_LANGUAGE}`
+        },
+        {
+          role: "user",
+          content: `In the sentence "我喜歡騎腳踏車但我更喜歡跑步" please translate the part "腳踏車" and just output the translated text`
+        },
+        {
+          role: "assistant",
+          content: `bicycle`
+        },
+        {
+          role: "user",
+          content: `In the sentence "${context}" please translate the part "${input}" and just output the translated text`
+        }
+      ]
+    };
+    
+    const completion = await createChatCompletionWithRetries(msgToGpt);
+    let result = completion.data.choices[0].message.content;
+    subtitles[i].data.text = `${result}\n${input}`
+    console.log(`-----------------`)
+    console.log(`${i + 1} / ${subtitles.length}`)
+    console.log(`${result}`)
+    console.log(`${input}`);
+  }
+  return subtitles;
 }
 
 for (let subtitleFile of subtitles) {
@@ -88,9 +95,10 @@ for (let subtitleFile of subtitles) {
   subtitle = fs.readFileSync(`./src/${subtitleFile}`, 'utf8')
   subtitle = parseSync(subtitle)
   subtitle = subtitle.filter(line => line.type === 'cue')
-  let waitingForResponse;
 
-  translateSubtitleLine(0, subtitleFile);
+  translateInPlace(subtitles);
+  
+  fs.writeFileSync(`./res/${filename}`, stringifySync(subtitles, { format: 'srt' }))
 }
 
 


### PR DESCRIPTION
Introduce a few utility functions and clean up existing ones:

1. Renamed `asyncCallWithTimeout` to `callWithTimeout`. If it reaches a timeout, it'll reject the Promise.
1. Introduced the `createChatCompletionWithRetries(msgToGpt)` function that will repeatedly call the API until it resolves with the result.
2. Replaced `translateSubtitleLine` into `translateInPlace` which also translates the whole array of subtitles. This time it uses a for loop instead of recursive calls.
3. Moved the re-write of the file into the main loop.